### PR TITLE
cloud watch logs role needed for the api gateway to be deployed

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -14,8 +14,30 @@ Globals:
         LOCAL_DDB_ENDPOINT: ""
 
 Resources:
+
+  # Add this new resource
+  ApiGatewayCloudWatchLogsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+
+  # Add this new resource
+  ApiGatewayAccountConfig:
+    Type: AWS::ApiGateway::Account
+    Properties:
+      CloudWatchRoleArn: !GetAtt ApiGatewayCloudWatchLogsRole.Arn
+
   RestApi:
     Type: AWS::Serverless::Api
+    DependsOn: ApiGatewayAccountConfig
     Properties:
       StageName: Prod
       Auth:


### PR DESCRIPTION
Hi, thanks for providing this template. It has been very helpful.

## Issue
When running `sam deploy`, I encountered the following error:

> 
> Resource handler returned message: "CloudWatch Logs role ARN must be set in account settings to enable logging (Service:  ApiGateway, Status Code:  400, Request ID: 842630f2-9b88-4ec9-a15551491b508711) (SDK Attempt Count: 1)" (RequestToken: 0
> 6d30652-b1e3-5955-c405-a4002b625aa5,HandlerErrorCode:InvalidRequest)
> 

## Investigation
Before opening this pull request, I attempted to reproduce the issue by:
1. Re-cloning the project
2. Deploying it as a new stack

I discovered that the deployment works in regions where I've previously deployed, but fails in new regions. This suggests the issue might be related to CloudWatch Logs role configuration in specific AWS regions.

## Reproduction Steps
To reproduce this issue:
- Try deploying the project into a different AWS region, or
- Delete your existing CloudWatch resources before redeploying

I'd appreciate any insights if you investigate this further.